### PR TITLE
Refacto project to ease the use of IBM Project Explorer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.vscode
+.logs
+.evfevent
+.env

--- a/README.md
+++ b/README.md
@@ -125,6 +125,14 @@ Welcome to the OSSILE project. This project is to serve three purposes:
 2. Use the RSTLIB command to restore the OSSILE library from the save file. For example:
   * ``RSTLIB SAVLIB(OSSILE) DEV(*SAVF) SAVF(MYLIB/MYSAVF)``
 
+#### Method 3: Deploy IBM Projects
+1. Give execution permision to the init script `chmod +x ./setup_workspace.sh `
+2. Execute `./setup_workspace.sh`
+3. Open the workspace
+4. Go to your project explorer and hit **Scan For Projects**
+5. Deploy the project and do the compilation
+> For more info about ibm projects check this [Modern IBM i pipeline repo](https://github.com/kraudy/IBM-i-pipeline)
+
 # OSSILE directory structure
 These are the main directories within OSSILE:
 ## ``main/``

--- a/code_examples/iproj.json
+++ b/code_examples/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "Code examples"
+}

--- a/main/arraylist/iproj.json
+++ b/main/arraylist/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "Arraylist"
+}

--- a/main/c_backup_pgm/README.md
+++ b/main/c_backup_pgm/README.md
@@ -1,4 +1,4 @@
-##Synopsis
+## Synopsis
 The purpose of this program is to use the IBM supplied backup process to save objects to an image catalog entry and then copy that image catalog entry to a
 remote file server. It can be used via the jobscheduler (shipped with every IBM i system) to create a back up process that will run automatically every
 night and carry out the required save process (use *SCHED). 
@@ -8,7 +8,7 @@ You will first need to set up the Image Catalogue and Virtual device. We suggest
 sufficient size to contain the backups you will capture. The IMGSIZE parameter will set the maximum size of the IMGCLGE, set the initial size to *MIN to allow
 the save to only take up as much DASD as you need. It is important atht the Volume Names match those set up in the BACKUP options.
 
-###Sample Commands to create above
+### Sample Commands to create above
 
 * `CRTDEVTAP DEVD(VRTTAP01) RSRCNAME(*VRT) ASSIGN(*YES)` 
 * `CRTIMGCLG IMGCLG(MYBACKUP) DIR('/mybackup') TYPE(*TAP)` 
@@ -21,7 +21,7 @@ Before you run the program you will need to set up your BACKUP settings via menu
 you have entered to carry out the backup to a virtual tape Image Catalog. Ensure you set the _Tape sets to rotate_ parameter matches the above Volume Name
 ie **DAYA** matches up with **DAYA01** for the daily backup.
 
-##Purpose
+## Purpose
 The daily save is developed so that it carries out a daily save and stores each nights save into a seperate directory on the file server. 
 The same IMGCLGE is used for each save. The reason for removing the image catalog each time is to keep the size of the images to a minimum, 
 you could add additional checks to initialize the image catalog but doing so would not reduce the size of the image each time.
@@ -33,16 +33,16 @@ Backup type `*SCHED,*DAILY,*WEEKLY,*MONTHLY`
 *SCHED uses the current date to determine type, it is what should be used when using via the job scheduler. The other parameters allow you to call
 the program from a command line and automatically start a backup of the desired type.
 
-##Tests
+## Tests
 Run a test of the settings using the command line and entering `CALL OSSILE/BACKUP '*DAILY'` this will cause the back up to use the daily settings entered
 in the Daily backup options.
 
-##Documentation
+## Documentation
 See [IBM Knowledge Center](http://www.ibm.com/support/knowledgecenter/ssw_ibm_i) for details of the API's used.
 
-##Contributors
+## Contributors
 Provided by Chris Hird. You can contact me via Ryver or Linked in should it be necessary.
 [Website](http://www.shieldadvanced.com)
    
-##Copyright
+## Copyright
 Copyright (c) Chris Hird 2016 Made available under the terms of the license of the containing project              

--- a/main/c_backup_pgm/iproj.json
+++ b/main/c_backup_pgm/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "C Backup Pgm"
+}

--- a/main/c_check_recvr_delete/README.md
+++ b/main/c_check_recvr_delete/README.md
@@ -1,7 +1,7 @@
-##Synopsis
+## Synopsis
 A program which shows how to display the recevivers attached to a journal and determine if the detach date is greater than the number of days passed.
 
-##Purpose
+## Purpose
 Demonstrates how to display a receiver chain and identify those receivers which are older than a number of days. It can be used to clean up a receiver
 chain attached to any journal (*LOCAL/*REMOTE) to allow DASD utilization to be managed.  
 
@@ -9,16 +9,16 @@ chain attached to any journal (*LOCAL/*REMOTE) to allow DASD utilization to be m
 * Journal 20 character 'JrnName   Library   '
 * Days to keep int
 
-##Tests
+## Tests
 Call from command line using the format CALL OSSILE/CHKRCVRDLT 'JrnName   Library' 2. this will print out those receivers which are detached and greater
 than 2 days old.
 
-##Documentation
+## Documentation
 See [IBM Knowledge Center](http://www.ibm.com/support/knowledgecenter/ssw_ibm_i) for details of the API's used.
 
-##Contributors
+## Contributors
 Provided by Chris Hird. You can contact me via Ryver or Linked in should it be necessary.
 [Website](http://www.shieldadvanced.com)
    
-##Copyright
+## Copyright
 Copyright (c) Chris Hird 2016 Made available under the terms of the license of the containing project              

--- a/main/c_check_recvr_delete/iproj.json
+++ b/main/c_check_recvr_delete/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "C Check Receiver Delete"
+}

--- a/main/c_chk_os_lvl/README.md
+++ b/main/c_chk_os_lvl/README.md
@@ -1,21 +1,21 @@
-##Synopsis
+## Synopsis
 Program that when called will output the current OS level.
 
-##Purpose
+## Purpose
 Demostrates how to get the current OS level in a program using the API's available.
 
 ## Parameters
 *NONE
 
-##Tests
+## Tests
 Test using the command line and entering `CALL OSSILE/CHKOSLVL`.
 
-##Documentation
+## Documentation
 See [IBM Knowledge Center](http://www.ibm.com/support/knowledgecenter/ssw_ibm_i) for details of the API's used.
 
-##Contributors
+## Contributors
 Provided by Chris Hird. You can contact me via Ryver or Linked in should it be necessary.
 [Website](http://www.shieldadvanced.com)
    
-##Copyright
+## Copyright
 Copyright (c) Chris Hird 2016 Made available under the terms of the license of the containing project              

--- a/main/c_chk_os_lvl/iproj.json
+++ b/main/c_chk_os_lvl/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "Check OS Level"
+}

--- a/main/c_display_constraints/README.md
+++ b/main/c_display_constraints/README.md
@@ -1,21 +1,21 @@
-##Synopsis
+## Synopsis
 Program that retrieves the constraints attached to a physical file and displays to stdout.
 
-##Purpose
+## Purpose
 Demostrates how to use the API's available to extract the constraints attached to a file and display them via stdout to the user.
 
 ## Parameters
 * File Name character 20 'FileName  Library   '
 
-##Tests
+## Tests
 Test using the command line and entering `CALL OSSILE/DSPCSTINF 'FileName  Library   '`.
 
-##Documentation
+## Documentation
 See [IBM Knowledge Center](http://www.ibm.com/support/knowledgecenter/ssw_ibm_i) for details of the API's used.
 
-##Contributors
+## Contributors
 Provided by Chris Hird. You can contact me via Ryver or Linked in should it be necessary.
 [Website](http://www.shieldadvanced.com)
    
-##Copyright
+## Copyright
 Copyright (c) Chris Hird 2016 Made available under the terms of the license of the containing project         

--- a/main/c_display_constraints/iproj.json
+++ b/main/c_display_constraints/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "C Display Constraints"
+}

--- a/main/c_display_triggers/README.md
+++ b/main/c_display_triggers/README.md
@@ -1,21 +1,21 @@
-##Synopsis
+## Synopsis
 Program that retrieves the triggers attached to a physical file and displays to stdout.
 
-##Purpose
+## Purpose
 Demostrates how to use the API's available to extract the triggers attached to a file and display them via stdout to the user.
 
 ## Parameters
 * File Name character 20 'FileName  Library   '
 
-##Tests
+## Tests
 Test using the command line and entering `CALL OSSILE/DSPTRGINF 'FileName  Library   '`.
 
-##Documentation
+## Documentation
 See [IBM Knowledge Center](http://www.ibm.com/support/knowledgecenter/ssw_ibm_i) for details of the API's used.
 
-##Contributors
+## Contributors
 Provided by Chris Hird. You can contact me via Ryver or Linked in should it be necessary.
 [Website](http://www.shieldadvanced.com)
    
-##Copyright
+## Copyright
 Copyright (c) Chris Hird 2016 Made available under the terms of the license of the containing project                  

--- a/main/c_display_triggers/iproj.json
+++ b/main/c_display_triggers/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "C Display Triggers"
+}

--- a/main/c_dspdqinf/README.md
+++ b/main/c_dspdqinf/README.md
@@ -1,22 +1,22 @@
-##Synopsis
+## Synopsis
 A program which shows how to display the attributes of a Data Queue Object.
 
-##Purpose
+## Purpose
 Allows the user to display the Data Queue Attributes.
 
 ## Parameters
 * Data Queue 20 character 'DtaqName  Library   '
 * Data Queue Type char '*STD' || '*DDM'
  
-##Tests
+## Tests
 call from command line using the format CALL OSSILE/DSPDSPDQINF 'DtaqName  Library' '*STD'
 
-##Documentation
+## Documentation
 See [IBM Knowledge Center](http://www.ibm.com/support/knowledgecenter/ssw_ibm_i) for details of the API's used.
 
-##Contributors
+## Contributors
 Provided by Chris Hird. You can contact me via Ryver or Linked in should it be necessary.
 [Website](http://www.shieldadvanced.com)
    
-##Copyright
+## Copyright
 Copyright (c) Chris Hird 2016 Made available under the terms of the license of the containing project              

--- a/main/c_dspdqinf/iproj.json
+++ b/main/c_dspdqinf/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "C Display Data Queue Attributes"
+}

--- a/main/c_dspusridx/README.md
+++ b/main/c_dspusridx/README.md
@@ -1,25 +1,25 @@
-##Synopsis
+## Synopsis
 A program which shows how to display the attributes of a User Index Object plus read the entries within the User Index and display to the user.
 
-##Purpose
+## Purpose
 Allows the user to display the User Index attributes and its content.
 
-##Note. 
+## Note. 
 The content must be in character format for the program to display it, if you need to display the content in a different format you will ned to adjust
 the code to output the relevant content in the desired format.
 
 ## Parameters
 * User Inddex 20 character 'IdxName   Library   '
 
-##Tests
+## Tests
 call from command line using the format CALL OSSILE/DSPUSRIDX 'IdxName   Library'
 
-##Documentation
+## Documentation
 See [IBM Knowledge Center](http://www.ibm.com/support/knowledgecenter/ssw_ibm_i) for details of the API's used.
 
-##Contributors
+## Contributors
 Provided by Chris Hird. You can contact me via Ryver or Linked in should it be necessary.
 [Website](http://www.shieldadvanced.com)
    
-##Copyright
+## Copyright
 Copyright (c) Chris Hird 2016 Made available under the terms of the license of the containing project              

--- a/main/c_dspusridx/iproj.json
+++ b/main/c_dspusridx/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "C Display User Index Attributes"
+}

--- a/main/c_ftpclnt/README.md
+++ b/main/c_ftpclnt/README.md
@@ -1,18 +1,18 @@
-##Synopsis
+## Synopsis
 A simple FTP Client for the IBM i using Panel Groups to display the local and remote content. The Panels provided allow complete control
 over the FTP process. Demonstrates various ILE techniques plus the use of a remote FTP server connection. Many of the techniques used can
 be used in other situations.
 
-##Purpose
+## Purpose
 Alternative to the IBM command line FTP client plus a demonstration of the capabilities of C on the IBM i
 
-##Documentation
+## Documentation
 * See [IBM Knowledge Center](http://www.ibm.com/support/knowledgecenter/ssw_ibm_i) for details of the API's used.
 * a sample manual is provided as a pdf, this can be provided in .docx format if required. see /main/c_ftpclnt/FTP_Client_OSS.pdf
 
-##Contributors
+## Contributors
 Provided by Chris Hird. You can contact me via Ryver or Linked in should it be necessary.
 [Website](http://www.shieldadvanced.com)
    
-##Copyright
+## Copyright
 Copyright (c) Chris Hird 2016 Made available under the terms of the license of the containing project              

--- a/main/c_ftpclnt/iproj.json
+++ b/main/c_ftpclnt/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "FTP Client for the IBM i"
+}

--- a/main/c_generic_server/iproj.json
+++ b/main/c_generic_server/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "Generic TCP Application Server"
+}

--- a/main/c_gunicorn_server/iproj.json
+++ b/main/c_gunicorn_server/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "Python Gunicorn Application Server"
+}

--- a/main/c_inih/iproj.json
+++ b/main/c_inih/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "Simple INI Parser"
+}

--- a/main/c_joblist/README.md
+++ b/main/c_joblist/README.md
@@ -1,21 +1,21 @@
-##Synopsis
+## Synopsis
 Program that when called will show a list of the jobs currently running on the system.
 
-##Purpose
+## Purpose
 Demostrates how to retrieve a list of jobs and display the information about each job..
 
 ## Parameters
 *NONE
 
-##Tests
+## Tests
 Test using the command line and entering `CALL OSSILE/JOBLIST`.
 
-##Documentation
+## Documentation
 See [IBM Knowledge Center](http://www.ibm.com/support/knowledgecenter/ssw_ibm_i) for details of the API's used.
 
-##Contributors
+## Contributors
 Provided by Chris Hird. You can contact me via Ryver or Linked in should it be necessary.
 [Website](http://www.shieldadvanced.com)
    
-##Copyright
+## Copyright
 Copyright (c) Chris Hird 2016 Made available under the terms of the license of the containing project              

--- a/main/c_joblist/iproj.json
+++ b/main/c_joblist/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "Retrieves list of jobs"
+}

--- a/main/c_list_dbr/README.md
+++ b/main/c_list_dbr/README.md
@@ -1,21 +1,21 @@
-##Synopsis
+## Synopsis
 Program that retrieves the database relationships for a file and displays to stdout.
 
-##Purpose
+## Purpose
 Demostrates how to use the API's available to extract the relational database information for a file and display it via stdout to the user.
 
 ## Parameters
 * File Name character 20 'FileName  Library   '
 
-##Tests
+## Tests
 Test using the command line and entering `CALL OSSILE/LSTDBRTST 'FileName  Library   '`.
 
-##Documentation
+## Documentation
 See [IBM Knowledge Center](http://www.ibm.com/support/knowledgecenter/ssw_ibm_i) for details of the API's used.
 
-##Contributors
+## Contributors
 Provided by Chris Hird. You can contact me via Ryver or Linked in should it be necessary.
 [Website](http://www.shieldadvanced.com)
    
-##Copyright
+## Copyright
 Copyright (c) Chris Hird 2016 Made available under the terms of the license of the containing project   

--- a/main/c_list_dbr/iproj.json
+++ b/main/c_list_dbr/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "Retrieves database relationships for a file"
+}

--- a/main/c_list_jrn_objs/README.md
+++ b/main/c_list_jrn_objs/README.md
@@ -1,7 +1,7 @@
-##Synopsis
+## Synopsis
 A program which shows how to display the objects journalled to a journal.
 
-##Purpose
+## Purpose
 Allows the user to display all of the objects journalled to a journal. It can be filtered by type such as *LIB, *DTAQ, *DTAARA, *FILE, *STMF.
 Special value of *ALL will display all object types. The *STMF request will use the API to extract the actual path of the object to display using its JID.
 
@@ -9,15 +9,15 @@ Special value of *ALL will display all object types. The *STMF request will use 
 * Journal 20 character 'JrnName   Library   '
 * Object type to display character 10 
 
-##Tests
+## Tests
 call from command line using the format CALL OSSILE/RTVJRNOBJ 'JrnName   Library' '*ALL      '
 
-##Documentation
+## Documentation
 See [IBM Knowledge Center](http://www.ibm.com/support/knowledgecenter/ssw_ibm_i) for details of the API's used.
 
-##Contributors
+## Contributors
 Provided by Chris Hird. You can contact me via Ryver or Linked in should it be necessary.
 [Website](http://www.shieldadvanced.com)
    
-##Copyright
+## Copyright
 Copyright (c) Chris Hird 2016 Made available under the terms of the license of the containing project              

--- a/main/c_list_jrn_objs/iproj.json
+++ b/main/c_list_jrn_objs/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "Show Objects Journalled to a Journal"
+}

--- a/main/c_md5crc/README.md
+++ b/main/c_md5crc/README.md
@@ -1,8 +1,8 @@
-##Synopsis
+## Synopsis
 A sample solution which reads the content of a file and generates a CRC for the entire content at either the file level or the memeber level. The user
 can determine which type of CRC is generated using an option in the command. Help is provided via a *PNLGRP for the command.
 
-##Purpose
+## Purpose
 Allows the user to generate a CRC for a file and compare that CRC with a copy of the object to ensure they are the same. The programs demonstrate how to
 create a ILE program and command using a Binding Directory to bind the module at compile time to the program object.
 
@@ -12,17 +12,17 @@ create a ILE program and command using a Binding Directory to bind the module at
 * CRC to use short int (restricted) 1 through 5.
 * Buffer size int (restricted) 32k - 16mb 
 
-##Tests
+## Tests
 Add the OSSILE library to the library list and run the command entering the information required. eg: 
 * CRTMD5 FILE(CORPDATA/EMPLOYEE) CRYPT(*SHA256) BUFSIZ(16MB)
 * output in MD5DETS 'EMPLOYEE  CORPDATA  EMPLOYEE  772dea81fc50683b758158a7e546756941e66735' 
 
-##Documentation
+## Documentation
 See [IBM Knowledge Center](http://www.ibm.com/support/knowledgecenter/ssw_ibm_i) for details of the API's used.
 
-##Contributors
+## Contributors
 Provided by Chris Hird. You can contact me via Ryver or Linked in should it be necessary.
 [Website](http://www.shieldadvanced.com)
    
-##Copyright
+## Copyright
 Copyright (c) Chris Hird 2016 Made available under the terms of the license of the containing project              

--- a/main/c_md5crc/iproj.json
+++ b/main/c_md5crc/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "Read File and Generate CRC"
+}

--- a/main/c_rtvdirsz/README.md
+++ b/main/c_rtvdirsz/README.md
@@ -1,7 +1,7 @@
-##Synopsis
+## Synopsis
 A program which walks through the directory passed and creates a log of the objects found plus their size.
 
-##Purpose
+## Purpose
 Shows how to use the API's available to retrieve the contents and subdirectories of a passed in directory and log each entry to a log file in the IFS.
 It will also sum the total number of objects and total size of the objects found.
 
@@ -14,16 +14,16 @@ Example:
 RTVDIRSZ PATH('/home')
 ```
 
-##Tests
+## Tests
 Use Command provided to prompt for directory and verify the results. The log will be in the directory '/home/rtvdirsz/log', in that directory will be a file
 which is named using the data and time the command was run.
 
-##Documentation
+## Documentation
 See [IBM Knowledge Center](http://www.ibm.com/support/knowledgecenter/ssw_ibm_i) for details of the API's used.
 
-##Contributors
+## Contributors
 Provided by Chris Hird. You can contact me via Ryver or Linked in should it be necessary.
 [Website](http://www.shieldadvanced.com)
    
-##Copyright
+## Copyright
 Copyright (c) Chris Hird 2016 Made available under the terms of the license of the containing project              

--- a/main/c_rtvdirsz/iproj.json
+++ b/main/c_rtvdirsz/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "Creates Log of IFS Dir Struct"
+}

--- a/main/c_signature_verification/README.md
+++ b/main/c_signature_verification/README.md
@@ -1,23 +1,23 @@
-##Synopsis
+## Synopsis
 A program which shows the signatures of a service program and then verifies that the signature for the service program relates to the signature 
 in a program. This ensures that a call to a function from the program to the service program will work.
 
-##Purpose
+## Purpose
 Verifies that the program will be able to call the service program functions without a signature violation.
 
 ## Parameters
 * Service Program Name 20 character 'SrvPgm    Library   '
 * Program Name 20 character 'PgmName   Library   ' 
 
-##Tests
+## Tests
 call from command line using the format CALL OSSILE/SRVPGMCHK 'SrvPgm    Library' 'PgmName   Library   '
 
-##Documentation
+## Documentation
 See [IBM Knowledge Center](http://www.ibm.com/support/knowledgecenter/ssw_ibm_i) for details of the API's used.
 
-##Contributors
+## Contributors
 Provided by Chris Hird. You can contact me via Ryver or Linked in should it be necessary.
 [Website](http://www.shieldadvanced.com)
    
-##Copyright
+## Copyright
 Copyright (c) Chris Hird 2016 Made available under the terms of the license of the containing project              

--- a/main/c_signature_verification/iproj.json
+++ b/main/c_signature_verification/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "Service Program Signature Verifier"
+}

--- a/main/c_sysinfo/README.md
+++ b/main/c_sysinfo/README.md
@@ -1,21 +1,21 @@
-##Synopsis
+## Synopsis
 Program that when called will show system information similar to the WRKSYSSTS command.
 
-##Purpose
+## Purpose
 Demostrates how to retrieve system status information using the API's available.
 
 ## Parameters
 *NONE
 
-##Tests
+## Tests
 Test using the command line and entering `CALL OSSILE/SYSINFO`.
 
-##Documentation
+## Documentation
 See [IBM Knowledge Center](http://www.ibm.com/support/knowledgecenter/ssw_ibm_i) for details of the API's used.
 
-##Contributors
+## Contributors
 Provided by Chris Hird. You can contact me via Ryver or Linked in should it be necessary.
 [Website](http://www.shieldadvanced.com)
    
-##Copyright
+## Copyright
 Copyright (c) Chris Hird 2016 Made available under the terms of the license of the containing project              

--- a/main/c_sysinfo/iproj.json
+++ b/main/c_sysinfo/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "Show system information similar to WRKSYSSTS"
+}

--- a/main/c_zlib/README.md
+++ b/main/c_zlib/README.md
@@ -1,12 +1,12 @@
-##Synopsis
+## Synopsis
 Open Source implementation of the ZLIB objects (ZIP/UNZIP etc). This is a direct port of the original ZLIB source for AS/400 which has been
 modified to run on V5R4M0 of the OS. A number of structure changes have been made to allow it to meet the OSSILE requirements.
 
-##Purpose
+## Purpose
 Provides ZIP/UNZIP capabilities for IBM i. 
 
 
-##Documentation
+## Documentation
 * See [IBM Knowledge Center](http://http://www.ibm.com/support/knowledgecenter/ssw_ibm_i) for details of the API's used.
 * The Change log shows the various changes in the source files  'main/c_zlib/qcsrc/changelog.txt'
 * Minizip has a change log 'main/c_zlib/qcsrc/changelogm.txt'
@@ -14,11 +14,11 @@ Provides ZIP/UNZIP capabilities for IBM i.
 * 'main/c_zlib/qcsrc/index.txt' provides a list of the files
 * 'main/c_zlib/qcsrc/faq.txt' provides responses to frequently asked questions about ZLIB.
 
-##Contributors
+## Contributors
 # see the list of contributors placed in the relevant files.
 Updates and restructuring for OSSILE Provided by Chris Hird. You can contact me via Ryver or Linked in should it be necessary.
 [Website](http://www.shieldadvanced.com)
    
-##Copyright
+## Copyright
 See original copyright notices in 'main/c_zlib/h/zlib.h'
 Copyright (c) Chris Hird 2016 Made available under the terms of the license of the containing project              

--- a/main/c_zlib/iproj.json
+++ b/main/c_zlib/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "Open Source implementation of ZLIB"
+}

--- a/main/crtfrmstmf/iproj.json
+++ b/main/crtfrmstmf/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "Create From Stream File"
+}

--- a/main/endalljob/iproj.json
+++ b/main/endalljob/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "End All Jobs with the Same Name"
+}

--- a/main/getiptf/iproj.json
+++ b/main/getiptf/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "Get PTF From Fix Central"
+}

--- a/main/linkedlist/iproj.json
+++ b/main/linkedlist/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "Linked List"
+}

--- a/main/message/iproj.json
+++ b/main/message/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "Wrappers for OS message APIs"
+}

--- a/main/nstat/iproj.json
+++ b/main/nstat/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "Batch Running NETSTAT"
+}

--- a/main/sha256/iproj.json
+++ b/main/sha256/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "SHA256 Implementation in C"
+}

--- a/main/su/.iproj.json
+++ b/main/su/.iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "Become Super User"
+}

--- a/main/su/readme.md
+++ b/main/su/readme.md
@@ -1,5 +1,5 @@
 ### SU
 
-##Just a little tool, i'm using under Linux and i like to found also on my favorite OS.
+## Just a little tool, i'm using under Linux and i like to found also on my favorite OS.
 
 *Never work's on IBMi as QSECOFR, but just type SU and you ARE QSECOFR !*

--- a/main/udf_retrieve_data_area/.iproj.json
+++ b/main/udf_retrieve_data_area/.iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "SQL Retrieve Data Area"
+}

--- a/main/udtf_cartridge_info/iproj.json
+++ b/main/udtf_cartridge_info/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "SQL UDTF Cartridge Info"
+}

--- a/main/udtf_history_log_info/iproj.json
+++ b/main/udtf_history_log_info/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "SQL UDTF History Log Info"
+}

--- a/main/udtf_image_catalog_details/iproj.json
+++ b/main/udtf_image_catalog_details/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "SQL UDTF Image Catalog Details"
+}

--- a/main/udtf_list_source_members/iproj.json
+++ b/main/udtf_list_source_members/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "SQL UDTF List Source Members"
+}

--- a/main/udtf_machine_attrs/iproj.json
+++ b/main/udtf_machine_attrs/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "SQL UDTF Machine Attributes"
+}

--- a/main/updusrattr/iproj.json
+++ b/main/updusrattr/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "Add Tag Object Attribute"
+}

--- a/setup_workspace.sh
+++ b/setup_workspace.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Set up VsCode config directory
+VSCODE_DIR="./.vscode"
+
+# Projects build list
+BUILD_LIST_FILE="./main/buildlist.txt"
+
+# Capture the current working directory
+CURRENT_DIR=$(pwd)
+
+# Print current working directory for confirmation
+echo "Current directory: $CURRENT_DIR"
+
+# Check if buildlist.txt exists
+if [ ! -f "$BUILD_LIST_FILE" ]; then
+    echo "Error: $BUILD_LIST_FILE not found in the current directory."
+    exit 1
+fi
+
+# Create the VSCODE_DIR directory if it doesn't exist
+mkdir -p "$VSCODE_DIR"
+
+# Start creating the OSSILE.code-workspace file
+cat << EOF > "$VSCODE_DIR/OSSILE.code-workspace"
+{
+    "folders": [
+EOF
+
+# Read each line from buildlist.txt and append to the folders array
+first_entry=true
+while IFS= read -r dirname; do
+    # Skip empty lines
+    [ -z "$dirname" ] && continue
+    # Add comma before subsequent entries
+    if [ "$first_entry" = false ]; then
+        echo "," >> "$VSCODE_DIR/OSSILE.code-workspace"
+    fi
+    # Add folder entry
+    cat << EOF >> "$VSCODE_DIR/OSSILE.code-workspace"
+        {
+            "name": "$dirname",
+            "path": "$CURRENT_DIR/main/$dirname"
+        }
+EOF
+    first_entry=false
+done < "$BUILD_LIST_FILE"
+
+# Add sql_example and code_example entries
+if [ "$first_entry" = false ]; then
+    echo "," >> "$VSCODE_DIR/OSSILE.code-workspace"
+fi
+cat << EOF >> "$VSCODE_DIR/OSSILE.code-workspace"
+        {
+            "name": "sql_examples",
+            "path": "$CURRENT_DIR/sql_examples"
+        },
+        {
+            "name": "code_examples",
+            "path": "$CURRENT_DIR/code_examples"
+        }
+EOF
+
+# Close the folders array and add settings
+cat << EOF >> "$VSCODE_DIR/OSSILE.code-workspace"
+    ],
+    "settings": {
+        "IBM i Project Explorer.projectScanDepth": 2
+    }
+}
+EOF
+
+echo "OSSILE.code-workspace file has been generated in $VSCODE_DIR directory with paths from $BUILD_LIST_FILE"

--- a/sql_examples/iproj.json
+++ b/sql_examples/iproj.json
@@ -1,0 +1,3 @@
+{
+  "description": "SQL Examples"
+}


### PR DESCRIPTION
First part of the proposal [Refacto utilities folder as ibm projects](https://github.com/OSSILE/OSSILE/issues/88) facilitates the deployment and compilation of individual projects and opens the possibility to define a Makefile to be used by gmake or BOB so that in a future PR developers can just do `git clone` and then hit `Run and Build` on the desired project explorer to have the utility they need created automatically.

This PR does not change or interfere with current functionality; the developer can still compile the project as usual.

After creating the workspace and opening it, you should see something like this.

![image](https://github.com/user-attachments/assets/9cec9888-3291-4d04-b408-b9ddad6d7ada)
